### PR TITLE
Reset input buffer on init

### DIFF
--- a/adafruit_tfmini.py
+++ b/adafruit_tfmini.py
@@ -49,6 +49,7 @@ class TFmini:
     def __init__(self, uart, *, timeout=1):
         self._uart = uart
         self._uart.baudrate = 115200
+        self._uart.reset_input_buffer()
         self.timeout = timeout
         self._strength = None
         self._mode = None


### PR DESCRIPTION
Reset input buffer on init (closes https://github.com/adafruit/Adafruit_CircuitPython_TFmini/issues/12)

If the base system is reset, some extra goop seems to stick around in the uart buffer.  Forcing a reset on restart fixes the problem.